### PR TITLE
Fixed feed content empty when user logged in

### DIFF
--- a/src/Controller/AbstractFeedController.php
+++ b/src/Controller/AbstractFeedController.php
@@ -168,6 +168,7 @@ abstract class AbstractFeedController implements RequestHandlerInterface
     /**
      * Retrieves an API response from the given endpoint.
      *
+     * @param Request $request
      * @param string $endpoint The API endpoint.
      * @param User   $actor    The request actor.
      * @param array  $params   The API request parameters (if any).
@@ -177,9 +178,9 @@ abstract class AbstractFeedController implements RequestHandlerInterface
      *
      * @return \stdClass API response.
      */
-    protected function getAPIDocument(string $endpoint, User $actor, array $params = [], array $body = [])
+    protected function getAPIDocument(Request $request, string $endpoint, User $actor, array $params = [], array $body = [])
     {
-        $response = $this->api->withQueryParams($params)->withBody($body)->withActor($actor)->get($endpoint);
+        $response = $this->api->withParentRequest($request)->withQueryParams($params)->withBody($body)->withActor($actor)->get($endpoint);
 
         if ($response->getStatusCode() === 404) {
             throw new RouteNotFoundException();
@@ -191,13 +192,14 @@ abstract class AbstractFeedController implements RequestHandlerInterface
     /**
      * Get the result of an API request to show the forum.
      *
+     * @param Request $request
      * @param User $actor
      *
      * @return \stdClass
      */
-    protected function getForumDocument(User $actor)
+    protected function getForumDocument(Request $request, User $actor)
     {
-        return $this->getAPIDocument('/', $actor)->data;
+        return $this->getAPIDocument($request, '/', $actor)->data;
     }
 
     /**

--- a/src/Controller/AbstractFeedController.php
+++ b/src/Controller/AbstractFeedController.php
@@ -169,10 +169,10 @@ abstract class AbstractFeedController implements RequestHandlerInterface
      * Retrieves an API response from the given endpoint.
      *
      * @param Request $request
-     * @param string $endpoint The API endpoint.
-     * @param User   $actor    The request actor.
-     * @param array  $params   The API request parameters (if any).
-     * @param array  $body     The API request body (if any).
+     * @param string  $endpoint The API endpoint.
+     * @param User    $actor    The request actor.
+     * @param array   $params   The API request parameters (if any).
+     * @param array   $body     The API request body (if any).
      *
      * @throws RouteNotFoundException If the API endpoint cannot be found, or if it cannot find what requested.
      *
@@ -193,7 +193,7 @@ abstract class AbstractFeedController implements RequestHandlerInterface
      * Get the result of an API request to show the forum.
      *
      * @param Request $request
-     * @param User $actor
+     * @param User    $actor
      *
      * @return \stdClass
      */

--- a/src/Controller/DiscussionFeedController.php
+++ b/src/Controller/DiscussionFeedController.php
@@ -70,14 +70,14 @@ class DiscussionFeedController extends AbstractFeedController
 
         $actor = $this->getActor($request);
 
-        $discussion = $this->getDiscussionsDocument($actor, [
+        $discussion = $this->getDiscussionsDocument($request, $actor, [
             'id'   => $discussion_id,
             'page' => [
                 'limit' => 1,
             ],
         ])->data;
 
-        $posts = $this->getPostsDocument($actor, [
+        $posts = $this->getPostsDocument($request, $actor, [
             'filter' => [
                 'discussion' => $discussion_id,
             ],
@@ -124,6 +124,7 @@ class DiscussionFeedController extends AbstractFeedController
     /**
      * Get the result of an API request to show a discussion.
      *
+     * @param Request $request
      * @param User  $actor
      * @param array $params
      *
@@ -131,14 +132,15 @@ class DiscussionFeedController extends AbstractFeedController
      *
      * @return object
      */
-    protected function getDiscussionsDocument(User $actor, array $params)
+    protected function getDiscussionsDocument(Request $request, User $actor, array $params)
     {
-        return $this->getAPIDocument('/discussions/'.$params['id'], $actor, $params);
+        return $this->getAPIDocument($request, '/discussions/'.$params['id'], $actor, $params);
     }
 
     /**
      * Get the result of an API request to list a discussion posts.
      *
+     * @param Request $request
      * @param User  $actor
      * @param array $params
      *
@@ -146,8 +148,8 @@ class DiscussionFeedController extends AbstractFeedController
      *
      * @return object
      */
-    protected function getPostsDocument(User $actor, array $params)
+    protected function getPostsDocument(Request $request, User $actor, array $params)
     {
-        return $this->getAPIDocument('/posts', $actor, $params);
+        return $this->getAPIDocument($request, '/posts', $actor, $params);
     }
 }

--- a/src/Controller/DiscussionFeedController.php
+++ b/src/Controller/DiscussionFeedController.php
@@ -125,8 +125,8 @@ class DiscussionFeedController extends AbstractFeedController
      * Get the result of an API request to show a discussion.
      *
      * @param Request $request
-     * @param User  $actor
-     * @param array $params
+     * @param User    $actor
+     * @param array   $params
      *
      * @throws RouteNotFoundException
      *
@@ -141,8 +141,8 @@ class DiscussionFeedController extends AbstractFeedController
      * Get the result of an API request to list a discussion posts.
      *
      * @param Request $request
-     * @param User  $actor
-     * @param array $params
+     * @param User    $actor
+     * @param array   $params
      *
      * @throws RouteNotFoundException
      *

--- a/src/Controller/DiscussionsActivityFeedController.php
+++ b/src/Controller/DiscussionsActivityFeedController.php
@@ -114,13 +114,13 @@ class DiscussionsActivityFeedController extends AbstractFeedController
         ];
 
         $actor = $this->getActor($request);
-        $forum = $this->getForumDocument($actor);
-        $last_discussions = $this->getDocument($actor, $params);
+        $forum = $this->getForumDocument($request, $actor);
+        $last_discussions = $this->getDocument($request, $actor, $params);
 
         $entries = [];
         $lastModified = null;
 
-        foreach ($last_discussions->data as $discussion) {
+        foreach ((array)$last_discussions->data as $discussion) {
             if ($discussion->type != 'discussions') {
                 continue;
             }
@@ -183,14 +183,15 @@ class DiscussionsActivityFeedController extends AbstractFeedController
     /**
      * Get the result of an API request to list discussions.
      *
+     * @param Request $request
      * @param User  $actor
      * @param array $params
      *
      * @return object
      */
-    private function getDocument(User $actor, array $params)
+    private function getDocument(Request $request, User $actor, array $params)
     {
-        return $this->getAPIDocument('/discussions', $actor, $params);
+        return $this->getAPIDocument($request, '/discussions', $actor, $params);
     }
 
     /**

--- a/src/Controller/DiscussionsActivityFeedController.php
+++ b/src/Controller/DiscussionsActivityFeedController.php
@@ -120,7 +120,7 @@ class DiscussionsActivityFeedController extends AbstractFeedController
         $entries = [];
         $lastModified = null;
 
-        foreach ((array)$last_discussions->data as $discussion) {
+        foreach ((array) $last_discussions->data as $discussion) {
             if ($discussion->type != 'discussions') {
                 continue;
             }
@@ -184,8 +184,8 @@ class DiscussionsActivityFeedController extends AbstractFeedController
      * Get the result of an API request to list discussions.
      *
      * @param Request $request
-     * @param User  $actor
-     * @param array $params
+     * @param User    $actor
+     * @param array   $params
      *
      * @return object
      */


### PR DESCRIPTION
Fixed this problem: https://discuss.flarum.org/d/27687-syndication-rss-atom-feeds/14

btw: When debug mode enabled, it cause a fatal error because it output a warning before the Response sent.

![image](https://user-images.githubusercontent.com/9024954/122814685-1ece4b00-d307-11eb-9b59-9dd6d02ace0d.png)

So I add a type casting at [this line](https://github.com/0xffff-one/flarum-ext-syndication/blob/ce33ba78f00f7bb6c966c02a4476449b63d835aa/src/Controller/DiscussionsActivityFeedController.php#L123)