### PR TITLE
fix: compatibility with blomstra/search

### DIFF
--- a/src/Controller/DiscussionsActivityFeedController.php
+++ b/src/Controller/DiscussionsActivityFeedController.php
@@ -90,18 +90,17 @@ class DiscussionsActivityFeedController extends AbstractFeedController
         $q = Arr::pull($queryParams, 'q');
         $tags = $this->getTags($request);
 
+        $filter = [];
+        if (!empty($q)) {
+            $filter['q'] = $q;
+        }
         if ($tags != null) {
-            $tags_search = [];
-            foreach ($tags as $tag) {
-                $tags_search[] = 'tag:'.$tag;
-            }
-
-            $q .= (!empty($q) ? ' ' : '').implode(' ', $tags_search);
+            $filter['tag'] = implode(',', $tags);
         }
 
         $params = [
             'sort'    => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : ($this->lastTopics ? $sortMap['newest'] : $sortMap['latest']),
-            'filter'  => compact('q'),
+            'filter'  => $filter,
             'page'    => ['offset' => 0, 'limit' => $this->getSetting('entries-count')],
             'include' => $this->lastTopics ? 'firstPost,user' : 'lastPost,lastPostedUser',
         ];


### PR DESCRIPTION
## Summary

- Pass tags via `filter[tag]` instead of embedding `tag:` gambits inside `filter[q]`.
- Omit `filter[q]` entirely when there is no free-text search term.

## Why

`blomstra/search` overrides `Flarum\Api\Client` in the container ([Provider.php](https://github.com/blomstra/flarum-ext-search/blob/main/src/Provider.php)) and hijacks any `/discussions` call where `filter[q]` is set, rerouting it to `/blomstra/search/discussions`. That handler passes `q` straight to Elasticsearch as free text — it does not parse `tag:` gambits — so RSS feeds that relied on `filter[q]=tag:foo` returned empty results.

By moving tags to the native `filter[tag]` param (handled by `TagFilterGambit` as a `FilterInterface`) and only setting `filter[q]` when there is an actual search term, the request stays on core's `/discussions` path on vanilla Flarum, with `flarum/tags`, and with `blomstra/search` installed.

Closes #17 — supersedes that PR with a cleaner implementation (no debug code, no absolute-URL workaround, correct comma-separated tag list).

## Test plan

- [ ] `/rss` returns discussions on vanilla Flarum
- [ ] `/rss/t/<slug>` returns tag-scoped discussions with `flarum/tags` only
- [ ] `/rss` and `/rss/t/<slug>` both work with `blomstra/search` enabled
- [ ] Multi-tag feeds (comma-separated) still filter correctly