### PR TITLE
fix: atom date handling and plain-text content rendering

### DIFF
--- a/src/Controller/AbstractFeedController.php
+++ b/src/Controller/AbstractFeedController.php
@@ -256,7 +256,16 @@ abstract class AbstractFeedController implements RequestHandlerInterface
      */
     protected function stripHTML($content)
     {
-        return $this->getSetting('html') ? $content : strip_tags($content);
+        if ($this->getSetting('html')) {
+            return $content;
+        }
+
+        // Decode entities so plain-text output does not leak `&amp;`, `&#39;`
+        // etc. into Atom <content type="text"> or RSS <description>.
+        $content = strip_tags($content);
+        $content = html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return trim(preg_replace('/\s+/u', ' ', $content));
     }
 
     /**

--- a/tests/integration/FeedFormatTest.php
+++ b/tests/integration/FeedFormatTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of ianm/syndication.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\FlarumFeeds\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class FeedFormatTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('ianm-syndication');
+
+        // Content deliberately contains HTML tags and entities so we can assert
+        // how the plain-text and html-passthrough render modes differ.
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Tom & Jerry: "A Tale"', 'slug' => 'tom-and-jerry', 'user_id' => 2, 'first_post_id' => 1, 'last_post_id' => 1, 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 2, 'created_at' => Carbon::now()->subHours(1), 'comment_count' => 1, 'is_private' => false],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>hello <em>world</em> &amp; friends</p></t>', 'created_at' => Carbon::now()->subHours(1), 'is_private' => false],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function atom_entry_has_published_and_updated_dates()
+    {
+        $response = $this->send($this->request('GET', '/atom'));
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Atom 1.0 spec (RFC 4287): some feed readers require <published> on
+        // every entry to display a first-posted date. <updated> alone is
+        // treated as "last modified" and can confuse readers.
+        $this->assertMatchesRegularExpression('#<entry>.*<published>[^<]+</published>.*</entry>#s', $body);
+        $this->assertMatchesRegularExpression('#<entry>.*<updated>[^<]+</updated>.*</entry>#s', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function atom_content_declares_type_attribute()
+    {
+        // Default html setting is off, so content should be plain text.
+        $response = $this->send($this->request('GET', '/atom'));
+        $body = (string) $response->getBody();
+
+        // Atom <content> defaults to type="text" when the attribute is absent,
+        // but some validators (and some readers) require an explicit type.
+        $this->assertStringContainsString('<content type="text">', $body);
+        $this->assertStringNotContainsString('<content type="html">', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function atom_content_declares_html_type_when_html_setting_enabled()
+    {
+        $this->setting('ianm-syndication.plugin.html', '1');
+
+        $response = $this->send($this->request('GET', '/atom'));
+        $body = (string) $response->getBody();
+
+        $this->assertStringContainsString('<content type="html">', $body);
+        $this->assertStringNotContainsString('<content type="text">', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function plain_text_mode_decodes_entities()
+    {
+        // html setting is off by default.
+        $response = $this->send($this->request('GET', '/atom'));
+        $body = (string) $response->getBody();
+
+        // The post body contains `<em>world</em> &amp; friends`. In plain-text
+        // mode we strip tags AND decode entities, so the ampersand should be
+        // rendered literally inside the CDATA block rather than as `&amp;`.
+        $this->assertStringContainsString('hello world & friends', $body);
+        $this->assertStringNotContainsString('&amp; friends', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function html_mode_preserves_markup_and_entities()
+    {
+        $this->setting('ianm-syndication.plugin.html', '1');
+
+        $response = $this->send($this->request('GET', '/atom'));
+        $body = (string) $response->getBody();
+
+        // In html passthrough mode the `<em>` should survive. Because it is
+        // inside CDATA the feed reader will render it as HTML.
+        $this->assertStringContainsString('<em>world</em>', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function rss_feed_decodes_entities_in_plain_text_mode()
+    {
+        $response = $this->send($this->request('GET', '/rss'));
+        $body = (string) $response->getBody();
+
+        $this->assertStringContainsString('hello world & friends', $body);
+        $this->assertStringNotContainsString('&amp; friends', $body);
+    }
+}

--- a/tests/integration/FeedFormatTest.php
+++ b/tests/integration/FeedFormatTest.php
@@ -1,10 +1,40 @@
 <?php
 
 /*
- * This file is part of ianm/syndication.
+ * Copyright or © or Copr. flarum-ext-syndication contributor : Amaury
+ * Carrade (2016)
  *
- * For the full copyright and license information, please view the LICENSE.md
- * file that was distributed with this source code.
+ * https://amaury.carrade.eu
+ *
+ * This software is a computer program whose purpose is to provides RSS
+ * and Atom feeds to Flarum.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ *
  */
 
 namespace IanM\FlarumFeeds\Tests\integration;

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -14,11 +14,9 @@
         <title><![CDATA[{!! $entry['title'] !!}]]></title>
         <link rel="alternate" type="text/html" href="{{ $entry['link'] }}"/>
         <id>{{ $entry['id'] }}</id>
-        <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
-        <content
-        @if ($html)
-            type="html"
-        @endif><![CDATA[{!! $entry['content'] !!}]]></content>
+        <published>{{ $entry['pubdate']->format(DateTime::ATOM) }}</published>
+        <updated>{{ ($entry['updated'] ?? $entry['pubdate'])->format(DateTime::ATOM) }}</updated>
+        <content type="{{ $html ? 'html' : 'text' }}"><![CDATA[{!! $entry['content'] !!}]]></content>
         <author>
             <name><![CDATA[{{ $entry['author'] }}]]></name>
         </author>


### PR DESCRIPTION
## Summary

Two bugs reported in #3 by @poVoq:

1. **Atom dates not visible in some feed readers** — entries had `<updated>` but no `<published>`. Per RFC 4287, `<updated>` is "last modified"; readers that expect a separate `<published>` for the first-posted date either hide or mislabel the timestamp. RSS only has `<pubDate>`, so the same data rendered fine there.
2. **Validator / render errors from un-stripped HTML** — `stripHTML()` called `strip_tags()` but did not decode entities, so plain-text output contained literal `&amp;`, `&#39;`, etc. Atom `<content>` also lacked an explicit `type` attribute, so readers treated the entity-laden string as plain text and displayed the entities verbatim.

## Changes

- `views/atom.blade.php`
  - Emits `<published>` (from `pubdate`) and `<updated>` (optional `updated` key on the entry, falls back to `pubdate`) on every entry.
  - `<content>` always declares `type="text"` or `type="html"` explicitly.
- `src/Controller/AbstractFeedController.php::stripHTML()`
  - After `strip_tags()`, decodes entities with `html_entity_decode(..., ENT_QUOTES | ENT_HTML5, 'UTF-8')` and collapses whitespace so plain-text output reads cleanly.
- `tests/integration/FeedFormatTest.php` — 6 new tests covering:
  - Atom entries have both `<published>` and `<updated>`
  - Atom `<content>` declares `type="text"` by default and `type="html"` when the html setting is enabled
  - Plain-text mode decodes entities in both Atom and RSS
  - HTML mode preserves markup

## Test plan

- [x] 31 tests, 78 assertions green locally
- [x] PHPStan clean
- [ ] CI matrix green
- [ ] Spot-check a real feed in Thunderbird / Feedly post-merge

Closes #3.