### PR TITLE
docs: refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-[![MIT license](https://img.shields.io/static/v1?label=license&message=CeCILL-B&color=blue)](https://github.com/imorland/syndication/blob/master/LICENSE)
+[![license](https://img.shields.io/static/v1?label=license&message=CeCILL-B&color=blue)](https://github.com/imorland/syndication/blob/1.x/LICENSE)
 [![Latest Stable Version](https://img.shields.io/packagist/v/ianm/syndication.svg)](https://packagist.org/packages/ianm/syndication)
 [![Total Downloads](https://img.shields.io/packagist/dt/ianm/syndication.svg)](https://packagist.org/packages/ianm/syndication)
+[![Backend CI](https://github.com/imorland/syndication/actions/workflows/backend.yml/badge.svg?branch=1.x)](https://github.com/imorland/syndication/actions/workflows/backend.yml)
 [![Compatibility](https://flarum-badge-api.davwheat.dev/v1/compat-latest/ianm/syndication)](https://flarum-badge-api.davwheat.dev/v1/compat-latest/ianm/syndication)
 
 # Syndication for [Flarum](https://flarum.org)
 
 Brings RSS and Atom feeds to Flarum.
 
-Based on [`amaurycarrade/flarum-ext-syndication`](https://github.com/AmauryCarrade/flarum-ext-syndication), seemingly now abandoned.  This fork, and the changes required to bring this extension back to life were sponsored by [010101](https://discuss.flarum.org/u/010101)
+Based on [`amaurycarrade/flarum-ext-syndication`](https://github.com/AmauryCarrade/flarum-ext-syndication), abandoned since 2019. This fork, and the changes required to bring the extension back to life, were sponsored by [010101](https://discuss.flarum.org/u/010101).
 
-Compatible with Flarum v1.0 and above
+Compatible with Flarum v1.0 and above.
 
 ### Installation
 
@@ -17,26 +18,41 @@ Compatible with Flarum v1.0 and above
 composer require ianm/syndication:"*"
 ```
 
-### Usage
+### Feeds
 
-This extension adds the following feeds to Flarum:
+| Route | Contents |
+| --- | --- |
+| `/atom` | Latest discussions with activity (the `/` page as a feed) |
+| `/atom/discussions` | Newly created discussions across the forum |
+| `/atom/d/{id}` | Recent posts in a single discussion (e.g. `/atom/d/21-discussion-slug`) |
+| `/atom/u/{username}/posts` | Recent posts by a single user |
+| `/atom/t/{slug}` | Latest discussions with activity in a tag *(requires `flarum/tags`)* |
+| `/atom/t/{slug}/discussions` | Newly created discussions in a tag *(requires `flarum/tags`)* |
 
-- `/atom`: feed with the last discussions with activity (the `/` page as an Atom feed);
-- `/atom/discussions`: feed with the newly created discussions in the forum;
-- `/atom/t/tag`: feed with the last discussions in the given tag (the `/t/tag` page as an Atom feed);
-- `/atom/t/tag/discussions`: feed with the newly created discussions in the given tag;
-- `/atom/d/21-discussion-slug`: feed with the recent posts in the given discussion.
+Replace `atom` with `rss` on any of these URLs to get the RSS variant.
 
-You can replace `atom` by `rss` in the URLs above to get RSS feeds instead. The tags-related feeds are only available if `flarum/tags` is installed and enabled.
+Discussion-list feeds accept `?sort=latest|top|newest|oldest` to reorder and `?q=<search>` to filter. Both can be combined: `?sort=<sorting>&q=<search>`.
 
-You can also add `?sort=latest|top|newest|oldest` to the discussions lists feeds to sort the feed, and `?q=<search>` to filter it. Or both using `?sort=<sorting>&q=<search>`.
+Feeds are linked in the page head for autodiscovery.
 
-Feeds are linked in the pages for autodiscovery. This said, they are not dynamically updated as the page change (except when fully reloaded), earlier because of this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=380639), and now because even Firefox no longer display RSS feeds in the browser.
+### Settings
+
+| Key | Default | Effect |
+| --- | --- | --- |
+| Full-Text Feeds | off | When off, post content is truncated to ~400 characters. When on, the full body is included. |
+| Formatted Feeds (HTML) | off | When off, HTML is stripped and entities are decoded so content is plain text. When on, the original HTML is passed through inside a CDATA block (Atom `<content type="html">`). |
+| Entries per feed | 100 | Maximum number of items in each feed response. |
+| Show feed links on the forum | off | Displays an RSS icon on the All Discussions, Tag and Discussion pages. |
+| Forum feed format | Atom | Which format the forum icons link to — Atom or RSS. |
+
+### Compatibility notes
+
+- **`blomstra/search`** — Tag feeds work with Blomstra's search extension installed. Tag filtering is passed through `filter[tag]` (handled by core's `TagFilterGambit` as a `FilterInterface`) rather than gambit-encoded in `filter[q]`, which previously caused Blomstra's Elasticsearch override to return empty results. See [#20](https://github.com/imorland/syndication/pull/20).
 
 ### Links
 
 - [Flarum Discuss post](https://discuss.flarum.org/d/27687)
 - [Source code on GitHub](https://github.com/imorland/syndication)
-- [Report an issue](https://github.com/imorland/syndication)
+- [Report an issue](https://github.com/imorland/syndication/issues)
 - [Packagist](https://packagist.org/packages/ianm/syndication)
 - [Extiverse](https://extiverse.com/extension/ianm/syndication)

--- a/README.md
+++ b/README.md
@@ -55,4 +55,3 @@ Feeds are linked in the page head for autodiscovery.
 - [Source code on GitHub](https://github.com/imorland/syndication)
 - [Report an issue](https://github.com/imorland/syndication/issues)
 - [Packagist](https://packagist.org/packages/ianm/syndication)
-- [Extiverse](https://extiverse.com/extension/ianm/syndication)


### PR DESCRIPTION
## Summary

- Fix dead LICENSE link — was pointing at `master`, but the default branch is `1.x`.
- Drop the misleading `MIT license` label on the license badge.
- Add a backend CI status badge.
- Document the `/u/{username}/posts` feed (added in 6391780) which wasn't listed.
- Reformat the feed list as a table and annotate the two tag-scoped routes as requiring `flarum/tags`.
- Add a settings table covering all five admin options (HTML passthrough, full-text, entries count, forum-format, forum-icons).
- Note the `blomstra/search` compatibility behaviour with a link to #20 so future reporters have context.
- Drop the decade-old Firefox autodiscovery aside.

No code changes.

## Test plan

- [x] Both external URLs (badge + LICENSE) return 200